### PR TITLE
Optimize GetMaxHealth patch

### DIFF
--- a/Source/QualityBionicsContinued/Patch/BodyPartDef_GetMaxHealth.cs
+++ b/Source/QualityBionicsContinued/Patch/BodyPartDef_GetMaxHealth.cs
@@ -9,29 +9,17 @@ namespace QualityBionicsContinued.Patch;
 [HarmonyPatch(typeof(BodyPartDef), nameof(BodyPartDef.GetMaxHealth))]
 public class BodyPartDef_GetMaxHealth
 {
-    private static bool? _skipCached = null;
-    private static bool Skip
+    [HarmonyPrepare]
+    private static bool ShouldPatch()
     {
-        get
-        {
-            if (!_skipCached.HasValue)
-            {
-                // Skip if EBF is running
-                _skipCached = LoadedModManager.RunningMods.Any(m => m.PackageIdPlayerFacing == "V1024.EBFramework");
-            }
-            return _skipCached.Value;
-        }
+        // Skip if EBF is running
+        QualityBionicsMod.WarningOnce("Skipping BodyPartDef_GetMaxHealth patch since EBF is present", 0x1337 + 0x69 - 0x420 + 0x1986);
+        return !LoadedModManager.RunningMods.Any(m => m.PackageIdPlayerFacing == "V1024.EBFramework");
     }
 
     [HarmonyPriority(Priority.Last)]
     private static void Postfix(BodyPartDef __instance, Pawn pawn, ref float __result)
     {
-        if (Skip)
-        {
-            QualityBionicsMod.WarningOnce("Skipping BodyPartDef_GetMaxHealth patch since EBF is present", 0x1337 + 0x69 - 0x420 + 0x1986);
-            return;
-        }
-
         foreach (var hediff in pawn.health.hediffSet.hediffs)
         {
             if (hediff.Part?.def == __instance)


### PR DESCRIPTION
This optimizes the GetMaxHealth patch by making use of Harmony's Prepare patch stage; see https://harmony.pardeike.net/articles/patching-auxiliary.html#prepare

This should result in a slight increase in performance in situations where GetMaxHealth is called many times in quick succession, e.g. when looking at the health cards of pawns.